### PR TITLE
min width for body

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -1,4 +1,5 @@
 body {
+  min-width: 320px;
   font-family: 'Fira Sans', sans-serif;
   color: #030a06;
   background-color: #ebf8ed;


### PR DESCRIPTION
обмежив мінімальну ширину для body щоб не ламало елементи при менших екранах від 320 px
